### PR TITLE
Remove ncu from dev script and add '기타' category

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "npx ncu && concurrently \"next dev\" \"tsx ./watcher.ts\" --kill-others",
+    "dev": "concurrently \"next dev\" \"tsx ./watcher.ts\" --kill-others",
     "next-dev": "next dev",
     "build": "next build",
     "start": "next start",
@@ -90,3 +90,4 @@
     "ws": "^8.17.0"
   }
 }
+

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4844871640976721, DIRECT, f08c47fec0942fa0

--- a/src/components/bars/LeftSidebar.tsx
+++ b/src/components/bars/LeftSidebar.tsx
@@ -12,6 +12,7 @@ const LeftSidebarComp = ({ menuclose }: { menuclose: any }) => {
   const [list, setList]: any[] = useState([
     { nameko: "개발", Subject: [] },
     { nameko: "개인학습", Subject: [] },
+    { nameko: "기타", Subject: [] },
   ]);
   useEffect(() => {
     fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/post/links`)
@@ -70,3 +71,4 @@ const LeftSidebarComp = ({ menuclose }: { menuclose: any }) => {
 };
 
 export default LeftSidebarComp;
+

--- a/src/components/bars/Navbar.tsx
+++ b/src/components/bars/Navbar.tsx
@@ -29,6 +29,7 @@ export const Navbar = () => {
   const [list, setList]: any[] = useState([
     { nameko: "개발", Subject: [] },
     { nameko: "개인학습", Subject: [] },
+    { nameko: "기타", Subject: [] },
   ]);
   useEffect(() => {
     fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/post/links`)
@@ -57,7 +58,7 @@ export const Navbar = () => {
             return (
               <Menubar
                 key={index}
-                className={"hidden border-none bg-transparent md:block "}
+                className={"hidden border-none bg-transparent md:block"}
               >
                 <MenubarMenu>
                   <MenubarTrigger
@@ -119,3 +120,4 @@ export const Navbar = () => {
     </>
   );
 };
+


### PR DESCRIPTION
Eliminate the use of ncu in the development script, introduce a new '기타' category in the sidebar, and add ads.txt for Google AdSense configuration.