### PR TITLE
Add YAML front matter template to blog code snippets

### DIFF
--- a/.vscode/blog.code-snippets
+++ b/.vscode/blog.code-snippets
@@ -2,6 +2,11 @@
   "Post list": {
     "prefix": "posting",
     "body": [
+      "---",
+      "title_ko: ",
+      "title_en: ",
+      "desc: ",
+      "---",
       "## 들어가기 전에",
       "",
       "## 본문 1",


### PR DESCRIPTION
Introduce a YAML front matter template for blog code snippets to standardize metadata inclusion.