### PR TITLE
Update TagList component to exclude '/aboutme' path

### DIFF
--- a/src/components/bars/TagList.tsx
+++ b/src/components/bars/TagList.tsx
@@ -22,7 +22,7 @@ const TagList = () => {
       });
   }, []);
 
-  if (pathname.startsWith("/blog/post")) {
+  if (pathname.startsWith("/blog/post") || pathname.startsWith("/aboutme")) {
     return null;
   }
   return (


### PR DESCRIPTION
Modify the TagList component to prevent rendering when the pathname starts with '/aboutme', in addition to the existing '/blog/post' condition.