### PR TITLE
Add optional metatag field to MdxMeta interface and update meta generation logic

### DIFF
--- a/src/config/types/types.ts
+++ b/src/config/types/types.ts
@@ -6,6 +6,7 @@ export interface MdxMeta {
   init_date: string;
   mod_date: string;
   url?: string;
+  metatag?: string[];
 }
 export interface urlParams {
   post: string;

--- a/src/lib/PostUtils/GenerateMeta.ts
+++ b/src/lib/PostUtils/GenerateMeta.ts
@@ -7,7 +7,7 @@ export const GenerateMeta = ({
   meta: MdxMeta;
   param: string;
 }) => {
-  const title = `PromleeBlog | ${meta.nameko}`;
+  const title = `${meta.nameko} | PromleeBlog`;
   const description = meta.desc;
   const tags: string[] = [
     "PromleeBlog",
@@ -17,6 +17,7 @@ export const GenerateMeta = ({
     meta.name,
     meta.desc,
     meta.url || "",
+    ...(meta.metatag?.map((tag) => tag) || []),
   ];
   const thumbnail = meta.thumbnail_url || "icons/android-chrome-512x512.png";
   const flattenedPath = `blog/post/${param}`;


### PR DESCRIPTION
Introduce an optional `metatag` field to the `MdxMeta` interface and modify the meta generation logic to include this field in the generated metadata.